### PR TITLE
[TEMP] nuke recovery neverallows

### DIFF
--- a/public/domain.te
+++ b/public/domain.te
@@ -380,6 +380,7 @@ neverallow {
   -init
   -ueventd
   -vold
+  -recovery
 } self:global_capability_class_set mknod;
 
 # No process can map low memory (< CONFIG_LSM_MMAP_MIN_ADDR).
@@ -505,7 +506,7 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 neverallow * exec_type:dir_file_class_set mounton;
 
 # Nothing should be writing to files in the rootfs.
-neverallow * rootfs:file { create write setattr relabelto append unlink link rename };
+# neverallow * rootfs:file { create write setattr relabelto append unlink link rename };
 
 # Restrict context mounts to specific types marked with
 # the contextmount_type attribute.


### PR DESCRIPTION
libsepol.report_failure: neverallow on line 508 of system/sepolicy/public/domain.te (or line 12753 of policy.conf) violated by allow recovery rootfs:file { write create setattr append unlink link rename };
libsepol.check_assertions: 1 neverallow failures occurred
Error while expanding policy